### PR TITLE
Add GitHub Actions workflow and devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/dotnet
+{
+	"name": "C# (.NET)",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/dotnet:2-9.0",
+	"features": {
+		"ghcr.io/devcontainers-extra/features/act:1": {}
+	}
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [5000, 5001],
+	// "portsAttributes": {
+	//		"5001": {
+	//			"protocol": "https"
+	//		}
+	// }
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "dotnet restore",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: weekly
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/unity-ci.yaml
+++ b/.github/workflows/unity-ci.yaml
@@ -1,0 +1,333 @@
+name: Unity CI
+
+run-name: 'Unity CI - ${{ github.event_name }} - ${{ github.ref_name }} - #${{ github.run_number }}'
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      runTests:
+        description: Run tests
+        required: false
+        default: true
+        type: boolean
+      buildAndroid:
+        description: Build Android
+        required: false
+        default: false
+        type: boolean
+      buildWindows:
+        description: Build Windows
+        required: false
+        default: true
+        type: boolean
+      buildWebGL:
+        description: Build WebGL
+        required: false
+        default: false
+        type: boolean
+      buildMacOS:
+        description: Build macOS
+        required: false
+        default: false
+        type: boolean
+      refreshLicenseOnly:
+        description: Refresh Unity license only
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  UNITY_VERSION: 2022.3.62f2
+  ARTIFACT_RETENTION_DAYS: 14
+
+jobs:
+  refresh_license:
+    name: Refresh Unity license
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.refreshLicenseOnly }}
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          lfs: true
+          fetch-depth: 0
+
+      - name: Create directories
+        run: mkdir -p artifacts/license
+
+      - name: Create Unity activation file
+        env:
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
+        run: |
+          docker run --rm \
+            -v "${GITHUB_WORKSPACE}:/project" \
+            -w /project \
+            -e UNITY_EMAIL \
+            -e UNITY_PASSWORD \
+            -e UNITY_LICENSE \
+            -e UNITY_SERIAL \
+            "unityci/editor:ubuntu-${{ env.UNITY_VERSION }}-base-3" \
+            bash -lc '
+              set -euo pipefail
+              mkdir -p artifacts/license
+              /opt/unity/Editor/Unity \
+                -batchmode \
+                -nographics \
+                -quit \
+                -projectPath /project \
+                -createManualActivationFile \
+                -logFile /project/artifacts/license/create-alf.log
+            '
+
+      - name: Validate activation file
+        run: test -f artifacts/license/Unity_v${{ env.UNITY_VERSION }}.alf || test -f Unity_v${{ env.UNITY_VERSION }}.alf
+
+      - name: Normalize activation file path
+        run: |
+          if [[ -f "Unity_v${{ env.UNITY_VERSION }}.alf" ]]; then
+            mv "Unity_v${{ env.UNITY_VERSION }}.alf" "artifacts/license/Unity_v${{ env.UNITY_VERSION }}.alf"
+          fi
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+
+      - name: Install GitHub CLI
+        run: |
+          type -p gh >/dev/null || (
+            (type -p wget >/dev/null || (sudo apt update && sudo apt install wget -y)) && \
+            sudo mkdir -p -m 755 /etc/apt/keyrings && \
+            out=$(mktemp) && wget -nv -O"$out" https://cli.github.com/packages/githubcli-archive-keyring.gpg && \
+            cat "$out" | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null && \
+            sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg && \
+            sudo mkdir -p -m 755 /etc/apt/sources.list.d && \
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
+            sudo apt update && \
+            sudo apt install gh -y
+          )
+
+      - name: Install license tools
+        run: npm install --global unity-license-activate unity-verify-code
+
+      - name: Activate Unity license
+        env:
+          UNITY_TOTP_KEY: ${{ secrets.UNITY_TOTP_KEY }}
+        run: |
+          command=(unity-license-activate "${{ secrets.UNITY_EMAIL }}" "${{ secrets.UNITY_PASSWORD }}" "artifacts/license/Unity_v${{ env.UNITY_VERSION }}.alf")
+
+          if [[ -n "${UNITY_TOTP_KEY:-}" ]]; then
+            command+=(--authenticator-key "$UNITY_TOTP_KEY")
+          fi
+
+          "${command[@]}"
+
+      - name: Read Unity license content
+        id: license_content
+        run: |
+          license_file=$(find . -type f -name '*.ulf' -print -quit)
+          test -n "$license_file"
+          delimiter="UNITY_LICENSE_$(date +%s)_$RANDOM"
+          {
+            echo "content<<$delimiter"
+            cat "$license_file"
+            echo
+            echo "$delimiter"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Update UNITY_LICENSE
+        env:
+          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          GH_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          LICENSE_CONTENT: ${{ steps.license_content.outputs.content }}
+        run: |
+          if [[ -z "${ACCESS_TOKEN:-}" ]]; then
+            echo "ACCESS_TOKEN is required to update UNITY_LICENSE" >&2
+            exit 1
+          fi
+
+          gh secret set UNITY_LICENSE --body "$LICENSE_CONTENT"
+
+  test:
+    name: Test ${{ matrix.testMode }}
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.runTests }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - testMode: EditMode
+            cacheScope: test-editmode
+          - testMode: PlayMode
+            cacheScope: test-playmode
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          lfs: true
+          fetch-depth: 0
+
+      - name: Cache Library
+        uses: actions/cache@v4
+        with:
+          path: Library
+          key: Library-${{ matrix.cacheScope }}-${{ env.UNITY_VERSION }}-${{ hashFiles('Packages/manifest.json', 'Packages/packages-lock.json', 'ProjectSettings/ProjectVersion.txt') }}
+          restore-keys: |
+            Library-${{ matrix.cacheScope }}-${{ env.UNITY_VERSION }}-
+            Library-${{ matrix.cacheScope }}-
+
+      - name: Run Unity tests
+        uses: game-ci/unity-test-runner@v4
+        env:
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+        with:
+          projectPath: .
+          unityVersion: ${{ env.UNITY_VERSION }}
+          testMode: ${{ matrix.testMode }}
+          artifactsPath: artifacts/test-results/${{ matrix.testMode }}
+
+      - name: Upload test artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ matrix.testMode }}
+          path: artifacts/test-results/${{ matrix.testMode }}
+          retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+          if-no-files-found: ignore
+
+      - name: Upload test logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-logs-${{ matrix.testMode }}
+          path: |
+            artifacts/test-results/${{ matrix.testMode }}/**/*.log
+            artifacts/test-results/${{ matrix.testMode }}/**/TestResults.xml
+            artifacts/test-results/${{ matrix.testMode }}/**/test-results.xml
+          retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+          if-no-files-found: ignore
+
+  build:
+    name: Build ${{ matrix.name }}
+    needs:
+      - test
+    if: ${{ always() && (needs.test.result == 'success' || needs.test.result == 'skipped' || (github.event_name == 'workflow_dispatch' && !inputs.runTests)) }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Android
+            enabled: ${{ github.event_name == 'workflow_dispatch' && inputs.buildAndroid }}
+            cacheScope: build-android
+            targetPlatform: Android
+            artifactName: build-android
+            logsArtifactName: build-logs-android
+            buildPath: build/Android
+            logPath: |
+              build/Android/**/*.log
+              build/Android/**/output.log
+              build/Android/**/UnityPlayer*.txt
+          - name: Windows
+            enabled: ${{ github.event_name != 'workflow_dispatch' || inputs.buildWindows }}
+            cacheScope: build-windows
+            targetPlatform: StandaloneWindows64
+            artifactName: build-windows
+            logsArtifactName: build-logs-windows
+            buildPath: build/StandaloneWindows64
+            logPath: |
+              build/StandaloneWindows64/**/*.log
+              build/StandaloneWindows64/**/output.log
+              build/StandaloneWindows64/**/UnityPlayer*.txt
+          - name: WebGL
+            enabled: ${{ github.event_name == 'workflow_dispatch' && inputs.buildWebGL }}
+            cacheScope: build-webgl
+            targetPlatform: WebGL
+            artifactName: build-webgl
+            logsArtifactName: build-logs-webgl
+            buildPath: build/WebGL
+            logPath: |
+              build/WebGL/**/*.log
+              build/WebGL/**/output.log
+          - name: macOS
+            enabled: ${{ github.event_name == 'workflow_dispatch' && inputs.buildMacOS }}
+            cacheScope: build-macos
+            targetPlatform: StandaloneOSX
+            artifactName: build-macos
+            logsArtifactName: build-logs-macos
+            buildPath: build/StandaloneOSX
+            logPath: |
+              build/StandaloneOSX/**/*.log
+              build/StandaloneOSX/**/output.log
+              build/StandaloneOSX/**/UnityPlayer*.txt
+    steps:
+      - name: Checkout repository
+        if: ${{ matrix.enabled }}
+        uses: actions/checkout@v5
+        with:
+          lfs: true
+          fetch-depth: 0
+
+      - name: Cache Library
+        if: ${{ matrix.enabled }}
+        uses: actions/cache@v4
+        with:
+          path: Library
+          key: Library-${{ matrix.cacheScope }}-${{ env.UNITY_VERSION }}-${{ hashFiles('Packages/manifest.json', 'Packages/packages-lock.json', 'ProjectSettings/ProjectVersion.txt') }}
+          restore-keys: |
+            Library-${{ matrix.cacheScope }}-${{ env.UNITY_VERSION }}-
+            Library-${{ matrix.cacheScope }}-
+
+      - name: Build ${{ matrix.name }} player
+        if: ${{ matrix.enabled }}
+        uses: game-ci/unity-builder@v4
+        env:
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+        with:
+          projectPath: .
+          unityVersion: ${{ env.UNITY_VERSION }}
+          targetPlatform: ${{ matrix.targetPlatform }}
+          buildsPath: build
+
+      - name: Upload ${{ matrix.name }} artifact
+        if: ${{ matrix.enabled }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifactName }}
+          path: ${{ matrix.buildPath }}
+          retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+          if-no-files-found: error
+
+      - name: Upload ${{ matrix.name }} logs
+        if: ${{ always() && matrix.enabled }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.logsArtifactName }}
+          path: ${{ matrix.logPath }}
+          retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+          if-no-files-found: ignore

--- a/.github/workflows/unity-ci.yaml
+++ b/.github/workflows/unity-ci.yaml
@@ -313,6 +313,7 @@ jobs:
           unityVersion: ${{ env.UNITY_VERSION }}
           targetPlatform: ${{ matrix.targetPlatform }}
           buildsPath: build
+          versioning: None
 
       - name: Upload ${{ matrix.name }} artifact
         if: ${{ matrix.enabled }}

--- a/README.md
+++ b/README.md
@@ -26,3 +26,36 @@ Dropbox因容量接近免费额度上限，未来将不会在dropbox上发布，
 *基础架构：Assets/Scripts/MVC/Model/Basic/  
 *战斗相关：Assets/Scripts/Scene Specific/Battle  
 
+## CI自动构建工作流
+
+仓库使用 GitHub Actions 自动执行 Unity CI，配置文件是 [`.github/workflows/unity-ci.yaml`](.github/workflows/unity-ci.yaml)。  
+它的作用很简单：
+
+- 推送到 `main` 时，自动跑测试并构建Windows版本
+- 提交Pull Request时，自动跑测试，避免明显问题进入主分支
+- 手动触发时，可以按需选择是否测试，以及构建 Android / Windows / WebGL / macOS
+- 构建完成后，会把产物和日志上传到GitHub Actions Artifacts，方便下载
+
+## 怎么使用这个CI？
+
+如果你想自己在GitHub上构建：
+
+0. Fork仓库
+1. 打开仓库的Actions页面
+2. 选择Unity CI工作流
+3. 点击Run workflow
+4. 勾选你要执行的内容
+5. 等待任务完成后，到本次运行的Artifacts下载构建结果和日志
+
+## 使用前需要准备什么？
+
+这个CI依赖Unity许可证相关的GitHub Secrets。没有这些配置时，工作流无法正常测试或构建。
+
+- `UNITY_EMAIL`
+- `UNITY_PASSWORD`
+- `UNITY_TOTP_KEY`
+- `UNITY_SERIAL`或`UNITY_LICENSE`
+- `ACCESS_TOKEN`：GitHub Token
+  - 权限：Read and Write access to secrets
+
+仓库里也提供了一个“只刷新许可证”的手动入口，可用于自动更新`UNITY_LICENSE`。


### PR DESCRIPTION
## 描述

这个PR为项目添加了GitHub Actions CI工作流和VS Code devcontainer配置，实现Unity项目的自动化构建和测试。

## 更改

- 添加 `.github/workflows/unity-ci.yaml` - Unity CI工作流
  - 推送到main分支时自动运行测试并构建Windows版本
  - PR提交时自动运行测试
  - 支持手动触发，可选构建 Android / Windows / WebGL / macOS
  - 构建产物和日志上传到GitHub Actions Artifacts

- 添加 `.devcontainer/devcontainer.json` - VS Code开发容器配置
  - 基于C# (.NET) 镜像
  - 包含act工具支持本地测试GitHub Actions

- 添加 `.github/dependabot.yml` - 依赖更新配置
  - 每周检查devcontainers和github-actions更新

- 更新 `README.md` - 添加CI使用说明

## 测试

> 或者查看我的仓库的构建：https://github.com/Lumysia/Seer2-Restart-Lite/actions

1. Fork仓库
2. 配置Unity相关的GitHub Secrets (`UNITY_EMAIL`, `UNITY_PASSWORD`, `UNITY_TOTP_KEY`, `UNITY_SERIAL`/`UNITY_LICENSE`, `ACCESS_TOKEN`)
3. 进入Actions页面，运行Unity CI工作流
4. 等待完成后下载构建产物

> 首次使用需要配置Unity许可证相关的GitHub Secrets，否则工作流无法正常执行测试或构建。  
> 自动构建目前只启用了Windows平台以节省时间，Android平台的构建需要超过30分钟。  


## 测试结果

1. 已经测试Windows平台的构建产物，目前一切正常。
2. macOS构建和游玩正常，但所有动画无法显示。看到代码内的动画加载部分似乎有Windows和Android的硬编码字符，但还没有仔细阅读代码。