### PR TITLE
fix: use VersionData.Compare for proper semantic version comparison

### DIFF
--- a/Assets/Scripts/Scene Specific/Title/TitleManager.cs
+++ b/Assets/Scripts/Scene Specific/Title/TitleManager.cs
@@ -117,7 +117,7 @@ public class TitleManager : Manager<TitleManager>
     }
 
     private bool CheckBuildVersion() {
-        if (GameManager.versionData.buildVersion == Application.version)
+        if (VersionData.Compare(Application.version, GameManager.versionData.buildVersion) >= 0)
             return true;
 
         startButton?.SetInteractable(false, false);


### PR DESCRIPTION
## 描述

修复了 `TitleManager.CheckBuildVersion()` 方法中的版本比较逻辑，使用 `VersionData.Compare()` 替代字符串相等比较。

## 问题

原来的实现使用 `==` 比较版本字符串，这会导致语义化版本比较不正确。云端版本似乎是非常旧的3.4.3？导致无法进入游戏
