### PR TITLE
修复“部分传送点无法点击”和“角色太空步”的bug

### DIFF
--- a/Assets/Scripts/MVC/Controller/Player/PlayerController.cs
+++ b/Assets/Scripts/MVC/Controller/Player/PlayerController.cs
@@ -19,7 +19,11 @@ public class PlayerController : Manager<PlayerController>
     {
         playerModel.OnPlayerMove();
         playerView.SetPlayerPosition(playerModel.currentPos);
-        if (!playerModel.isMoving)
+        if (playerModel.isMoving)
+        {
+            playerView.SetDirection(playerModel.direction);
+        }
+        else
         {
             playerView.SetDirection(new Vector2(0, 0));
             if (pathPreviewVisible)
@@ -97,6 +101,15 @@ public class PlayerController : Manager<PlayerController>
         if (!playerModel.SetDestinationByCanvasPos(canvasPos, onArrive))
             return;
 
+        playerView.SetDirection(playerModel.direction);
+    }
+
+    public void SetDestinationNearCanvasPos(Vector2 canvasPos, float searchRadius, Action onArrive = null)
+    {
+        if (!playerModel.SetDestinationNearCanvasPos(canvasPos, searchRadius, onArrive))
+            return;
+
+        UpdatePathPreview();
         playerView.SetDirection(playerModel.direction);
     }
 

--- a/Assets/Scripts/MVC/Model/Player/PlayerModel.cs
+++ b/Assets/Scripts/MVC/Model/Player/PlayerModel.cs
@@ -56,6 +56,17 @@ public class PlayerModel : Module
         return true;
     }
 
+    public bool SetDestinationNearCanvasPos(Vector2 destination, float searchRadius, Action onArrive)
+    {
+        if (navigator == null)
+            navigator = new MapNavigator(map, canvasSize);
+
+        if (!navigator.TryFindNearestReachablePoint(destination, searchRadius, out var reachableDestination))
+            return false;
+
+        return SetDestinationByCanvasPos(reachableDestination, onArrive);
+    }
+
     /// <summary>
     /// <paramref name="anchor"/> Bottom-left (0, 0). Top-right (1, 1).
     /// </summary>

--- a/Assets/Scripts/Scene Specific/Map/Entities/Teleport/TeleportHandler.cs
+++ b/Assets/Scripts/Scene Specific/Map/Entities/Teleport/TeleportHandler.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 public static class TeleportHandler
 {
     public static ResourceManager RM => ResourceManager.instance;
+    private const float TeleportReachableSearchRadius = 72f;
 
     public static void CreateTeleport(Dictionary<int, GameObject> teleportList, GameObject teleport, TeleportInfo info, InfoPrompt infoPrompt) {
         SetTeleportRect(teleport, info);
@@ -30,7 +31,7 @@ public static class TeleportHandler
     }
 
     public static void Transport(Vector2 canvasPos, Action onArrive) {
-        PlayerController.instance.SetDestinationByCanvasPos(canvasPos, onArrive);
+        PlayerController.instance.SetDestinationNearCanvasPos(canvasPos, TeleportReachableSearchRadius, onArrive);
     }
 
     public static void Teleport(TeleportInfo info) {

--- a/Assets/Scripts/Scene Specific/Map/MapNavigator.cs
+++ b/Assets/Scripts/Scene Specific/Map/MapNavigator.cs
@@ -27,7 +27,7 @@ public class MapNavigator
     public float footprint => footprintRadius;
     public float gridCellSize => cellSize;
 
-    public MapNavigator(Map map, Vector2 canvasSize, float cellSize = 8f, float footprintRadius = 14f)
+    public MapNavigator(Map map, Vector2 canvasSize, float cellSize = 8f, float footprintRadius = 8f)
     {
         this.map = map;
         this.canvasSize = canvasSize;
@@ -59,6 +59,50 @@ public class MapNavigator
         }
 
         return true;
+    }
+
+    public bool TryFindNearestReachablePoint(Vector2 center, float searchRadius, out Vector2 point)
+    {
+        point = center;
+        if (IsTargetReachable(center))
+            return true;
+
+        Vector2Int origin = CanvasToCell(center);
+        int maxCellRadius = Mathf.CeilToInt(Mathf.Max(0f, searchRadius) / cellSize);
+        float bestDistanceSquared = float.PositiveInfinity;
+        bool found = false;
+
+        for (int radius = 1; radius <= maxCellRadius; radius++)
+        {
+            bool foundAtRadius = false;
+            for (int y = origin.y - radius; y <= origin.y + radius; y++)
+            {
+                for (int x = origin.x - radius; x <= origin.x + radius; x++)
+                {
+                    if (Mathf.Abs(x - origin.x) != radius && Mathf.Abs(y - origin.y) != radius)
+                        continue;
+
+                    var cell = new Vector2Int(x, y);
+                    if (!IsCellWalkable(cell))
+                        continue;
+
+                    Vector2 candidate = CellToCanvas(cell);
+                    float distanceSquared = (candidate - center).sqrMagnitude;
+                    if (distanceSquared > searchRadius * searchRadius || distanceSquared >= bestDistanceSquared)
+                        continue;
+
+                    point = candidate;
+                    bestDistanceSquared = distanceSquared;
+                    found = true;
+                    foundAtRadius = true;
+                }
+            }
+
+            if (foundAtRadius)
+                return true;
+        }
+
+        return found;
     }
 
     public bool TryFindPath(Vector2 from, Vector2 to, out List<Vector2> path)


### PR DESCRIPTION
### **BUG1：部分传送点无法点击**
原因：新增角色的 `footprint` 属性数值过大，导致部分狭窄可通行区域被判定为不可到达。而传送点触发逻辑依赖角色抵达后才能生效，因此出现点击无响应问题。

修复方案：
1. 调小碰撞判定所用的 `footprint` 数值，优化区域判定规则；
2. 优化传送点交互逻辑：直接点击传送点时即使该地点不可达，角色也会自动移动至传送点周边可达区域，再执行传送逻辑。

---

### **BUG2：角色出现“太空步”异常**
原因：角色方向仅在首次点击时赋值，切换至下一个路径点（waypoint）后，未同步通知视图层更新方向状态。

修复方案：
在 `PlayerController.FixedUpdate()` 移动逻辑中，持续依据 `playerModel.direction` 刷新角色动画朝向；当 A* 路径切换至下一个 waypoint 时，角色方向会同步更新为新路径走向，动画状态随之正常切换。