### PR TITLE
更新了Map的xml文件中与wander相关的标签格式

### DIFF
--- a/Assets/Resources/Data/Maps/10015.xml
+++ b/Assets/Resources/Data/Maps/10015.xml
@@ -49,13 +49,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="1001504" resId="Pets/pet/10038" name="Lv21 火炎贝" size="40,70" pos="420,180" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>全身被熔岩外壳覆盖，摸起来……别摸！很烫！</self>
-				<self>火焰！火苗苗~</self>
-				<self>火炎贝：一只从岩浆里爬出来的小家伙。</self>
-			</wanderBubble>
+		<npc id="1001504" resId="Pets/pet/10038" name="Lv21 火炎贝" size="40,70" pos="420,180" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>全身被熔岩外壳覆盖，摸起来……别摸！很烫！</self>
+					<self>火焰！火苗苗~</self>
+					<self>火炎贝：一只从岩浆里爬出来的小家伙。</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true">
@@ -92,13 +93,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="1001505" resId="Pets/pet/10038" name="Lv22 火炎贝" size="40,70" pos="265,220" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>我从岩浆里出生的！是不是很厉害？</self>
-				<self>熔壳！免疫燃烧，火来了也不怕！</self>
-				<self>火山星山脚下的温度刚刚好~</self>
-			</wanderBubble>
+		<npc id="1001505" resId="Pets/pet/10038" name="Lv22 火炎贝" size="40,70" pos="265,220" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>我从岩浆里出生的！是不是很厉害？</self>
+					<self>熔壳！免疫燃烧，火来了也不怕！</self>
+					<self>火山星山脚下的温度刚刚好~</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true">

--- a/Assets/Resources/Data/Maps/10016.xml
+++ b/Assets/Resources/Data/Maps/10016.xml
@@ -285,13 +285,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="1001604" resId="Pets/pet/10035" name="Lv23 吉尔" size="56,70" pos="420,180" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>火花！噼里啪啦~</self>
-				<self>炽翼！火系技能10%让对手烧伤！</self>
-				<self>龙爪！龙系技能伤害增加25%！</self>
-			</wanderBubble>
+		<npc id="1001604" resId="Pets/pet/10035" name="Lv23 吉尔" size="56,70" pos="420,180" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>火花！噼里啪啦~</self>
+					<self>炽翼！火系技能10%让对手烧伤！</self>
+					<self>龙爪！龙系技能伤害增加25%！</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true">
@@ -311,13 +312,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="1001605" resId="Pets/pet/10035" name="Lv24 吉尔" size="56,70" pos="320,325" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>烟幕！看不见我了吧~</self>
-				<self>抓！……抓到了空气。</self>
-				<self>吉尔在火山里散步~地面好烫！但我不怕~</self>
-			</wanderBubble>
+		<npc id="1001605" resId="Pets/pet/10035" name="Lv24 吉尔" size="56,70" pos="320,325" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>烟幕！看不见我了吧~</self>
+					<self>抓！……抓到了空气。</self>
+					<self>吉尔在火山里散步~地面好烫！但我不怕~</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true">

--- a/Assets/Resources/Data/Maps/10017.xml
+++ b/Assets/Resources/Data/Maps/10017.xml
@@ -289,13 +289,14 @@
 				</button>
 			</callbackHandler>
 		</npc>
-		<npc id="1001704" resId="Pets/pet/10335" name="Lv26 赤甲虫" size="64,48" pos="450,300" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>火花！噼啪~</self>
-				<self>焰舞！火系技能10%让对手昏迷！</self>
-				<self>温室！10%获得火环之心~</self>
-			</wanderBubble>
+		<npc id="1001704" resId="Pets/pet/10335" name="Lv26 赤甲虫" size="64,48" pos="450,300" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>火花！噼啪~</self>
+					<self>焰舞！火系技能10%让对手昏迷！</self>
+					<self>温室！10%获得火环之心~</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true">
@@ -315,13 +316,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="1001705" resId="Pets/pet/10335" name="Lv27 赤甲虫" size="64,48" pos="270,260" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>火焰之环！转圈圈~</self>
-				<self>赤甲虫的心情：温度高就开心，温度低就……困。</self>
-				<self>火山星深处是我的地盘！别过来！……除非你带好吃的。</self>
-			</wanderBubble>
+		<npc id="1001705" resId="Pets/pet/10335" name="Lv27 赤甲虫" size="64,48" pos="270,260" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>火焰之环！转圈圈~</self>
+					<self>赤甲虫的心情：温度高就开心，温度低就……困。</self>
+					<self>火山星深处是我的地盘！别过来！……除非你带好吃的。</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true">

--- a/Assets/Resources/Data/Maps/10020.xml
+++ b/Assets/Resources/Data/Maps/10020.xml
@@ -49,13 +49,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="1002002" resId="Pets/pet/10030" name="Lv11 贝尔" size="46,44" pos="635,70" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>缩头！躲进壳里~</self>
-				<self>稳固！雨天减伤10%！</self>
-				<self>贝尔最喜欢和朋友们一起在岩石上晒太阳了~</self>
-			</wanderBubble>
+		<npc id="1002002" resId="Pets/pet/10030" name="Lv11 贝尔" size="46,44" pos="635,70" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>缩头！躲进壳里~</self>
+					<self>稳固！雨天减伤10%！</self>
+					<self>贝尔最喜欢和朋友们一起在岩石上晒太阳了~</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true">
@@ -92,13 +93,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="1002003" resId="Pets/pet/10030" name="Lv12 贝尔" size="46,44" pos="460,80" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>水枪！噗噗噗~</self>
-				<self>波涛！有水之波动就免疫异常状态~</self>
-				<self>今天又找到了一块好晒太阳的岩石~</self>
-			</wanderBubble>
+		<npc id="1002003" resId="Pets/pet/10030" name="Lv12 贝尔" size="46,44" pos="460,80" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>水枪！噗噗噗~</self>
+					<self>波涛！有水之波动就免疫异常状态~</self>
+					<self>今天又找到了一块好晒太阳的岩石~</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true">

--- a/Assets/Resources/Data/Maps/10021.xml
+++ b/Assets/Resources/Data/Maps/10021.xml
@@ -80,13 +80,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="1002104" resId="Pets/pet/10198" name="Lv13 小鳍鱼" size="69,60" pos="420,180" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>我的鱼鳍很漂亮吧？每天都要打理的！</self>
-				<self>海洋星深水区好深好蓝~</self>
-				<self>成群出现时海水会变成彩虹色哦~</self>
-			</wanderBubble>
+		<npc id="1002104" resId="Pets/pet/10198" name="Lv13 小鳍鱼" size="69,60" pos="420,180" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>我的鱼鳍很漂亮吧？每天都要打理的！</self>
+					<self>海洋星深水区好深好蓝~</self>
+					<self>成群出现时海水会变成彩虹色哦~</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true">
@@ -106,13 +107,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="1002105" resId="Pets/pet/10198" name="Lv14 小鳍鱼" size="69,60" pos="290,130" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>摆尾！甩甩甩~</self>
-				<self>破浪！对手体力高时伤害增加10%！</self>
-				<self>鳞甲！深海减伤~</self>
-			</wanderBubble>
+		<npc id="1002105" resId="Pets/pet/10198" name="Lv14 小鳍鱼" size="69,60" pos="290,130" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>摆尾！甩甩甩~</self>
+					<self>破浪！对手体力高时伤害增加10%！</self>
+					<self>鳞甲！深海减伤~</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true">

--- a/Assets/Resources/Data/Maps/10026.xml
+++ b/Assets/Resources/Data/Maps/10026.xml
@@ -39,13 +39,14 @@
 				</button>
 			</callbackHandler>
 		</npc>
-		<npc id="1002602" resId="Pets/pet/10025" name="Lv38 幽浮" size="74,46" pos="600,140" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>加速！快快快~</self>
-				<self>身体轻盈到可以飘起来~</self>
-				<self>燕返！飞出去又飞回来~</self>
-			</wanderBubble>
+		<npc id="1002602" resId="Pets/pet/10025" name="Lv38 幽浮" size="74,46" pos="600,140" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>加速！快快快~</self>
+					<self>身体轻盈到可以飘起来~</self>
+					<self>燕返！飞出去又飞回来~</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true">
@@ -65,13 +66,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="1002603" resId="Pets/pet/10025" name="Lv39 幽浮" size="74,46" pos="250,90" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>幽浮特性！对手眩晕时我减伤~</self>
-				<self>幻光！攻击命中10%让对手迷惑~</self>
-				<self>幽浮：神出鬼没，来去无踪……偶尔撞墙。</self>
-			</wanderBubble>
+		<npc id="1002603" resId="Pets/pet/10025" name="Lv39 幽浮" size="74,46" pos="250,90" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>幽浮特性！对手眩晕时我减伤~</self>
+					<self>幻光！攻击命中10%让对手迷惑~</self>
+					<self>幽浮：神出鬼没，来去无踪……偶尔撞墙。</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true">

--- a/Assets/Resources/Data/Maps/10027.xml
+++ b/Assets/Resources/Data/Maps/10027.xml
@@ -29,13 +29,14 @@
 				</button>
 			</callbackHandler>
 		</npc>
-		<npc id="1002702" resId="Pets/pet/10249" name="Lv41 浮空苗" size="36,33" pos="350,115" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>旋风！呼呼呼~</self>
-				<self>气流！风系攻击还能让对手干裂~</self>
-				<self>对光源很敏感，天一黑我就想睡觉~</self>
-			</wanderBubble>
+		<npc id="1002702" resId="Pets/pet/10249" name="Lv41 浮空苗" size="36,33" pos="350,115" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>旋风！呼呼呼~</self>
+					<self>气流！风系攻击还能让对手干裂~</self>
+					<self>对光源很敏感，天一黑我就想睡觉~</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true">
@@ -55,13 +56,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="1002703" resId="Pets/pet/10249" name="Lv42 浮空苗" size="36,33" pos="200,90" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>鸣叫！叽~</self>
-				<self>冲顶！顶顶顶~</self>
-				<self>浮空苗飘在云层上方，世界好安静~</self>
-			</wanderBubble>
+		<npc id="1002703" resId="Pets/pet/10249" name="Lv42 浮空苗" size="36,33" pos="200,90" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>鸣叫！叽~</self>
+					<self>冲顶！顶顶顶~</self>
+					<self>浮空苗飘在云层上方，世界好安静~</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true">

--- a/Assets/Resources/Data/Maps/10031.xml
+++ b/Assets/Resources/Data/Maps/10031.xml
@@ -15,13 +15,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="1003101" resId="Pets/pet/10043" name="Lv54 罗奇" size="36,38" pos="345,340" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>罗奇的小窝在夹缝里，虽然小但很温馨~</self>
-				<self>电气震！电一下！</self>
-				<self>以金属为食的精灵，你见过几个？</self>
-			</wanderBubble>
+		<npc id="1003101" resId="Pets/pet/10043" name="Lv54 罗奇" size="36,38" pos="345,340" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>罗奇的小窝在夹缝里，虽然小但很温馨~</self>
+					<self>电气震！电一下！</self>
+					<self>以金属为食的精灵，你见过几个？</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>
@@ -39,13 +40,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="1003102" resId="Pets/pet/10043" name="Lv53 罗奇" size="36,38" pos="680,230" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>电磁！麻痹几率提升20%！</self>
-				<self>电轮！50%几率加速~</self>
-				<self>阴谋！偷偷谋划~</self>
-			</wanderBubble>
+		<npc id="1003102" resId="Pets/pet/10043" name="Lv53 罗奇" size="36,38" pos="680,230" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>电磁！麻痹几率提升20%！</self>
+					<self>电轮！50%几率加速~</self>
+					<self>阴谋！偷偷谋划~</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>

--- a/Assets/Resources/Data/Maps/10035.xml
+++ b/Assets/Resources/Data/Maps/10035.xml
@@ -15,13 +15,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="1003501" resId="Pets/pet/10145" name="Lv48 吉斯" size="24,44" pos="530,360" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>折磨！让对手难受~</self>
-				<self>吉斯：严肃、刻板、但很可靠。</self>
-				<self>圣殿守护了这么久，偶尔也会想出去走走~</self>
-			</wanderBubble>
+		<npc id="1003501" resId="Pets/pet/10145" name="Lv48 吉斯" size="24,44" pos="530,360" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>折磨！让对手难受~</self>
+					<self>吉斯：严肃、刻板、但很可靠。</self>
+					<self>圣殿守护了这么久，偶尔也会想出去走走~</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>
@@ -39,13 +40,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="1003502" resId="Pets/pet/10145" name="Lv49 吉斯" size="24,44" pos="365,280" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>精灵圣殿由我守护，闲人勿进！</self>
-				<self>正极！减伤10%！负极！增伤10%！</self>
-				<self>守护圣殿是我的使命，不能懈怠！</self>
-			</wanderBubble>
+		<npc id="1003502" resId="Pets/pet/10145" name="Lv49 吉斯" size="24,44" pos="365,280" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>精灵圣殿由我守护，闲人勿进！</self>
+					<self>正极！减伤10%！负极！增伤10%！</self>
+					<self>守护圣殿是我的使命，不能懈怠！</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>

--- a/Assets/Resources/Data/Maps/10036.xml
+++ b/Assets/Resources/Data/Maps/10036.xml
@@ -4,13 +4,14 @@
 		<bgm>BGM_36</bgm>
 	</music>
 	<entities>
-		<npc id="1003601" resId="Pets/pet/10010" name="Lv1 皮皮" size="56,42" pos="420,200" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>我的耳朵可是武器哦！别小看它们~</self>
-				<self>克洛斯星草原好大，适合蹦蹦跳跳！</self>
-				<self>鸣叫！叽叽叽~</self>
-			</wanderBubble>
+		<npc id="1003601" resId="Pets/pet/10010" name="Lv1 皮皮" size="56,42" pos="420,200" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>我的耳朵可是武器哦！别小看它们~</self>
+					<self>克洛斯星草原好大，适合蹦蹦跳跳！</self>
+					<self>鸣叫！叽叽叽~</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>
@@ -45,13 +46,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="1003602" resId="Pets/pet/10010" name="Lv2 皮皮" size="56,42" pos="265,140" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>燕返！飞过去又飞回来~</self>
-				<self>皮皮最喜欢热闹了！快来和我玩！</self>
-				<self>大耳朵拍拍！啪啪啪~</self>
-			</wanderBubble>
+		<npc id="1003602" resId="Pets/pet/10010" name="Lv2 皮皮" size="56,42" pos="265,140" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>燕返！飞过去又飞回来~</self>
+					<self>皮皮最喜欢热闹了！快来和我玩！</self>
+					<self>大耳朵拍拍！啪啪啪~</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>

--- a/Assets/Resources/Data/Maps/10037.xml
+++ b/Assets/Resources/Data/Maps/10037.xml
@@ -4,13 +4,14 @@
 		<bgm>BGM_36</bgm>
 	</music>
 	<entities>
-		<npc id="1003701" resId="Pets/pet/10016" name="Lv3 仙人球" size="45,80" pos="460,100" namePos="0,-10" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>仙人球：高傲、带刺、不好惹。</self>
-				<self>刺身撞击！连人带刺一起撞过去~</self>
-				<self>缩头！……我没有头可以缩。那就缩刺吧。</self>
-			</wanderBubble>
+		<npc id="1003701" resId="Pets/pet/10016" name="Lv3 仙人球" size="45,80" pos="460,100" namePos="0,-10">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>仙人球：高傲、带刺、不好惹。</self>
+					<self>刺身撞击！连人带刺一起撞过去~</self>
+					<self>缩头！……我没有头可以缩。那就缩刺吧。</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true">
@@ -47,13 +48,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="1003702" resId="Pets/pet/10016" name="Lv4 仙人球" size="45,80" pos="600,70" namePos="0,-10" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>别碰我！我浑身都是刺！</self>
-				<self>克洛斯星沼泽虽然湿漉漉的，但我喜欢~</self>
-				<self>针刺！扎扎扎~</self>
-			</wanderBubble>
+		<npc id="1003702" resId="Pets/pet/10016" name="Lv4 仙人球" size="45,80" pos="600,70" namePos="0,-10">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>别碰我！我浑身都是刺！</self>
+					<self>克洛斯星沼泽虽然湿漉漉的，但我喜欢~</self>
+					<self>针刺！扎扎扎~</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true">

--- a/Assets/Resources/Data/Maps/123.xml
+++ b/Assets/Resources/Data/Maps/123.xml
@@ -6,14 +6,16 @@
 		<fx>FX_103</fx>
 	</music>
 	<entities>
-		<npc id="12301" resId="Pets/pet/210.png" name="Lv16 弗格" size="36,38" pos="580,150" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			<wanderBubble>
-				<self>别看我个子小，我可是很重的哦！踩我脚试试？</self>
-				<self>今天的蘑菇长得不错……算了，还是晒太阳比较重要。</self>
-				<self>光合作用中……请勿打扰！</self>
-				<self>山谷里的雾气好重，我的叶子都快发霉了……</self>
-				<self></self>
-			</wanderBubble>
+		<npc id="12301" resId="Pets/pet/210.png" name="Lv16 弗格" size="36,38" pos="580,150" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>别看我个子小，我可是很重的哦！踩我脚试试？</self>
+					<self>今天的蘑菇长得不错……算了，还是晒太阳比较重要。</self>
+					<self>光合作用中……请勿打扰！</self>
+					<self>山谷里的雾气好重，我的叶子都快发霉了……</self>
+					<self></self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>
@@ -31,14 +33,16 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="12302" resId="Pets/pet/210.png" name="Lv17 弗格" size="36,38" pos="410,100" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			<wanderBubble>
-				<self>我偷偷练了旋转击！转起来的时候连我自己都晕~</self>
-				<self>听说沙漠那边阳光很好……啊，不小心说出来了。</self>
-				<self>谁说草系不能很重？我这叫"扎根式体重"！</self>
-				<self>今天好像有精灵在附近中毒了……不是我干的！大概。</self>
-				<self></self>
-			</wanderBubble>
+		<npc id="12302" resId="Pets/pet/210.png" name="Lv17 弗格" size="36,38" pos="410,100" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>我偷偷练了旋转击！转起来的时候连我自己都晕~</self>
+					<self>听说沙漠那边阳光很好……啊，不小心说出来了。</self>
+					<self>谁说草系不能很重？我这叫"扎根式体重"！</self>
+					<self>今天好像有精灵在附近中毒了……不是我干的！大概。</self>
+					<self></self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>
@@ -56,14 +60,16 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="12303" resId="Pets/pet/210.png" name="Lv18 弗格" size="36,38" pos="290,80" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			<wanderBubble>
-				<self>再生能力发动！感觉……嗯，还是有点困。</self>
-				<self>我虽然住在蘑菇小径，但我的梦想可不止蘑菇那么大。</self>
-				<self>有时候会想，山谷外面的世界，是不是真的有金色的沙子呢？</self>
-				<self>狂野皮肤练好了！……其实就是把皮肤绷紧一点啦。</self>
-				<self></self>
-			</wanderBubble>
+		<npc id="12303" resId="Pets/pet/210.png" name="Lv18 弗格" size="36,38" pos="290,80" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>再生能力发动！感觉……嗯，还是有点困。</self>
+					<self>我虽然住在蘑菇小径，但我的梦想可不止蘑菇那么大。</self>
+					<self>有时候会想，山谷外面的世界，是不是真的有金色的沙子呢？</self>
+					<self>狂野皮肤练好了！……其实就是把皮肤绷紧一点啦。</self>
+					<self></self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>

--- a/Assets/Resources/Data/Maps/124.xml
+++ b/Assets/Resources/Data/Maps/124.xml
@@ -110,13 +110,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="12403" resId="Pets/pet/204.png" name="Lv16 芙拉" size="37,62" pos="500,180" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>我没有根！我是自由的花朵~</self>
-				<self>异蘑谷的蘑菇和我的花瓣很配呢~</self>
-				<self>漂浮着到处旅行，世界好大！</self>
-			</wanderBubble>
+		<npc id="12403" resId="Pets/pet/204.png" name="Lv16 芙拉" size="37,62" pos="500,180" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>我没有根！我是自由的花朵~</self>
+					<self>异蘑谷的蘑菇和我的花瓣很配呢~</self>
+					<self>漂浮着到处旅行，世界好大！</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true" />
@@ -134,13 +135,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="12404" resId="Pets/pet/204.png" name="Lv17 芙拉" size="37,62" pos="350,70" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>亮叶光束！叶子闪闪发光~</self>
-				<self>铁木保护！变硬变硬~</self>
-				<self>毒枝！对手中毒时我伤害更高~</self>
-			</wanderBubble>
+		<npc id="12404" resId="Pets/pet/204.png" name="Lv17 芙拉" size="37,62" pos="350,70" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>亮叶光束！叶子闪闪发光~</self>
+					<self>铁木保护！变硬变硬~</self>
+					<self>毒枝！对手中毒时我伤害更高~</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true" />

--- a/Assets/Resources/Data/Maps/131.xml
+++ b/Assets/Resources/Data/Maps/131.xml
@@ -7,13 +7,14 @@
 		<fx>FX_109</fx>
 	</music>
 	<entities>
-		<npc id="13101" resId="Pets/pet/13.png" name="Lv5 小小葵" size="36,38" pos="290,150" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>葵花种子准备好了，谁来和我玩？</self>
-				<self>下雨天也不错，雨水甜甜的~</self>
-				<self>别踩我的叶子！……开玩笑的啦。</self>
-			</wanderBubble>
+		<npc id="13101" resId="Pets/pet/13.png" name="Lv5 小小葵" size="36,38" pos="290,150" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>葵花种子准备好了，谁来和我玩？</self>
+					<self>下雨天也不错，雨水甜甜的~</self>
+					<self>别踩我的叶子！……开玩笑的啦。</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true">
@@ -50,13 +51,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="13102" resId="Pets/pet/13.png" name="Lv6 小小葵" size="36,38" pos="420,120" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>阳光特性发动！感觉浑身暖洋洋的~</self>
-				<self>听说自然界里有很多好朋友，好想都认识一下！</self>
-				<self>有时候会和小虫子聊天，它们都很害羞。</self>
-			</wanderBubble>
+		<npc id="13102" resId="Pets/pet/13.png" name="Lv6 小小葵" size="36,38" pos="420,120" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>阳光特性发动！感觉浑身暖洋洋的~</self>
+					<self>听说自然界里有很多好朋友，好想都认识一下！</self>
+					<self>有时候会和小虫子聊天，它们都很害羞。</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true">
@@ -76,13 +78,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="13103" resId="Pets/pet/13.png" name="Lv7 小小葵" size="36,38" pos="580,80" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>今天的阳光刚刚好，多晒一会儿~</self>
-				<self>三叶草又长出新芽了，好开心！</self>
-				<self>我是荆棘林里最会光合作用的！</self>
-			</wanderBubble>
+		<npc id="13103" resId="Pets/pet/13.png" name="Lv7 小小葵" size="36,38" pos="580,80" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>今天的阳光刚刚好，多晒一会儿~</self>
+					<self>三叶草又长出新芽了，好开心！</self>
+					<self>我是荆棘林里最会光合作用的！</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true">

--- a/Assets/Resources/Data/Maps/133.xml
+++ b/Assets/Resources/Data/Maps/133.xml
@@ -7,13 +7,14 @@
 		<fx>FX_114</fx>
 	</music>
 	<entities>
-		<npc id="13301" resId="Pets/pet/200.png" name="Lv10 荧光蝶" size="62,62" pos="320,60" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>我发光了！是不是很好看~</self>
-				<self>深幽沼泽虽然名字不太好听，但其实是我的家~</self>
-				<self>我不太擅长战斗……但我会发光呀！</self>
-			</wanderBubble>
+		<npc id="13301" resId="Pets/pet/200.png" name="Lv10 荧光蝶" size="62,62" pos="320,60" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>我发光了！是不是很好看~</self>
+					<self>深幽沼泽虽然名字不太好听，但其实是我的家~</self>
+					<self>我不太擅长战斗……但我会发光呀！</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true" />
@@ -39,13 +40,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="13302" resId="Pets/pet/200.png" name="Lv11 荧光蝶" size="62,62" pos="200,90" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>腐蚀花粉！花粉弥漫~</self>
-				<self>荧光特性！对手有荧光花粉时我每回合回血~</self>
-				<self>虚弱花粉！让对手变弱~</self>
-			</wanderBubble>
+		<npc id="13302" resId="Pets/pet/200.png" name="Lv11 荧光蝶" size="62,62" pos="200,90" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>腐蚀花粉！花粉弥漫~</self>
+					<self>荧光特性！对手有荧光花粉时我每回合回血~</self>
+					<self>虚弱花粉！让对手变弱~</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true" />
@@ -71,13 +73,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="13303" resId="Pets/pet/200.png" name="Lv12 荧光蝶" size="62,62" pos="130,180" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>俯冲！……飞太低了，撞到泥巴了。</self>
-				<self>居民区的精灵们都很喜欢我发的光~</self>
-				<self>荧光蝶的日常：发光、飞舞、偶尔迷路。</self>
-			</wanderBubble>
+		<npc id="13303" resId="Pets/pet/200.png" name="Lv12 荧光蝶" size="62,62" pos="130,180" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>俯冲！……飞太低了，撞到泥巴了。</self>
+					<self>居民区的精灵们都很喜欢我发的光~</self>
+					<self>荧光蝶的日常：发光、飞舞、偶尔迷路。</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true" />

--- a/Assets/Resources/Data/Maps/151.xml
+++ b/Assets/Resources/Data/Maps/151.xml
@@ -7,13 +7,14 @@
     	<fx>FX_117</fx>
     </music>
 	<entities>
-		<npc id="15101" resId="Pets/pet/20.png" name="Lv13 奇鲁" size="48,54" pos="145,180" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>我可是从石头缝里钻出来的！厉害吧？</self>
-				<self>水枪准备好了！……呃，先喝口水再说。</self>
-				<self>头顶这块石头好重，但我不怕！</self>
-			</wanderBubble>
+		<npc id="15101" resId="Pets/pet/20.png" name="Lv13 奇鲁" size="48,54" pos="145,180" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>我可是从石头缝里钻出来的！厉害吧？</self>
+					<self>水枪准备好了！……呃，先喝口水再说。</self>
+					<self>头顶这块石头好重，但我不怕！</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true">
@@ -50,13 +51,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="15102" resId="Pets/pet/20.png" name="Lv14 奇鲁" size="48,54" pos="270,240" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>流水特性发动！水系技能威力up up~</self>
-				<self>有时候会想，石头外面是什么样子呢？</self>
-				<self>穿击波！……打偏了。</self>
-			</wanderBubble>
+		<npc id="15102" resId="Pets/pet/20.png" name="Lv14 奇鲁" size="48,54" pos="270,240" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>流水特性发动！水系技能威力up up~</self>
+					<self>有时候会想，石头外面是什么样子呢？</self>
+					<self>穿击波！……打偏了。</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true">
@@ -93,13 +95,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="15103" resId="Pets/pet/20.png" name="Lv15 奇鲁" size="48,54" pos="350,190" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>终于把大石头顶开了！外面的世界好大啊~</self>
-				<self>失明免疫！谁也蒙不了我的眼睛！</self>
-				<self>水仙草界的水好清澈，游起来很舒服~</self>
-			</wanderBubble>
+		<npc id="15103" resId="Pets/pet/20.png" name="Lv15 奇鲁" size="48,54" pos="350,190" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>终于把大石头顶开了！外面的世界好大啊~</self>
+					<self>失明免疫！谁也蒙不了我的眼睛！</self>
+					<self>水仙草界的水好清澈，游起来很舒服~</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true">

--- a/Assets/Resources/Data/Maps/180.xml
+++ b/Assets/Resources/Data/Maps/180.xml
@@ -6,13 +6,14 @@
     	<fx>FX_119</fx>
     </music>
 	<entities>
-		<npc id="18001" resId="Pets/pet/41.png" name="Lv23 水墨点点" size="20,34" pos="500,80" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>逆流！逆流而上！……被冲回来了。</self>
-				<self>银脉山脊的水好凉快，最适合散步~</self>
-				<self>虽然不能畅游，但我在水中走路也很优雅的！</self>
-			</wanderBubble>
+		<npc id="18001" resId="Pets/pet/41.png" name="Lv23 水墨点点" size="20,34" pos="500,80" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>逆流！逆流而上！……被冲回来了。</self>
+					<self>银脉山脊的水好凉快，最适合散步~</self>
+					<self>虽然不能畅游，但我在水中走路也很优雅的！</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>
@@ -47,13 +48,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="18002" resId="Pets/pet/41.png" name="Lv24 水墨点点" size="20,34" pos="720,140" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>虚弱水枪！……水枪也虚弱了？不，是让对手虚弱！</self>
-				<self>小时候被嘲笑的事……现在想想也没什么啦~</self>
-				<self>哼，总有一天我要学会游泳的！……大概。</self>
-			</wanderBubble>
+		<npc id="18002" resId="Pets/pet/41.png" name="Lv24 水墨点点" size="20,34" pos="720,140" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>虚弱水枪！……水枪也虚弱了？不，是让对手虚弱！</self>
+					<self>小时候被嘲笑的事……现在想想也没什么啦~</self>
+					<self>哼，总有一天我要学会游泳的！……大概。</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>

--- a/Assets/Resources/Data/Maps/192.xml
+++ b/Assets/Resources/Data/Maps/192.xml
@@ -6,13 +6,14 @@
     	<fx>FX_120</fx>
     </music>
 	<entities>
-		<npc id="19201" resId="Pets/pet/28.png" name="Lv21 蓝喵" size="47,35" pos="500,200" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>今天撞了三块石头，两根柱子，一个……NPC。</self>
-				<self>星之力发动！速度嗖嗖的~</self>
-				<self>蓝喵出击！目标：前方那块看起来很硬的东西！</self>
-			</wanderBubble>
+		<npc id="19201" resId="Pets/pet/28.png" name="Lv21 蓝喵" size="47,35" pos="500,200" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>今天撞了三块石头，两根柱子，一个……NPC。</self>
+					<self>星之力发动！速度嗖嗖的~</self>
+					<self>蓝喵出击！目标：前方那块看起来很硬的东西！</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>
@@ -48,13 +49,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="19202" resId="Pets/pet/28.png" name="Lv22 蓝喵" size="47,35" pos="720,140" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>谁说蓝喵胆小？我敢撞任何东西！</self>
-				<self>全力冲撞！……头好疼。</self>
-				<self>残骸通道里好多东西可以撞，开心！</self>
-			</wanderBubble>
+		<npc id="19202" resId="Pets/pet/28.png" name="Lv22 蓝喵" size="47,35" pos="720,140" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>谁说蓝喵胆小？我敢撞任何东西！</self>
+					<self>全力冲撞！……头好疼。</self>
+					<self>残骸通道里好多东西可以撞，开心！</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>

--- a/Assets/Resources/Data/Maps/203.xml
+++ b/Assets/Resources/Data/Maps/203.xml
@@ -6,13 +6,14 @@
     	<fx>FX_120</fx>
     </music>
 	<entities>
-		<npc id="20301" resId="Pets/pet/72.png" name="Lv27 乌达" size="46,58" pos="400,310" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>潮水技能！让对手溺水几率提升~</self>
-				<self>有时候会吵架，但过一会儿又黏在一起了。</self>
-				<self>脱力！……不是我们脱力了，是让对手脱力！</self>
-			</wanderBubble>
+		<npc id="20301" resId="Pets/pet/72.png" name="Lv27 乌达" size="46,58" pos="400,310" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>潮水技能！让对手溺水几率提升~</self>
+					<self>有时候会吵架，但过一会儿又黏在一起了。</self>
+					<self>脱力！……不是我们脱力了，是让对手脱力！</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>
@@ -30,13 +31,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="20302" resId="Pets/pet/72.png" name="Lv28 乌达" size="46,58" pos="520,250" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>我们是两个！不是两个头，是两只精灵！</self>
-				<self>黏在一起久了，有时候会忘记谁是哪个。</self>
-				<self>蓄水！水量充足，伤害加成~</self>
-			</wanderBubble>
+		<npc id="20302" resId="Pets/pet/72.png" name="Lv28 乌达" size="46,58" pos="520,250" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>我们是两个！不是两个头，是两只精灵！</self>
+					<self>黏在一起久了，有时候会忘记谁是哪个。</self>
+					<self>蓄水！水量充足，伤害加成~</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>

--- a/Assets/Resources/Data/Maps/204.xml
+++ b/Assets/Resources/Data/Maps/204.xml
@@ -6,13 +6,14 @@
     	<fx>FX_120</fx>
     </music>
 	<entities>
-		<npc id="20401" resId="Pets/pet/141.png" name="Lv29 希捷特" size="54,48" pos="340,260" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>虚空充能！能量蓄满~</self>
-				<self>幽静珊瑚穴好安静，适合练习空间跳跃。</self>
-				<self>窒息冲锋！……对手窒息了，我也快窒息了。</self>
-			</wanderBubble>
+		<npc id="20401" resId="Pets/pet/141.png" name="Lv29 希捷特" size="54,48" pos="340,260" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>虚空充能！能量蓄满~</self>
+					<self>幽静珊瑚穴好安静，适合练习空间跳跃。</self>
+					<self>窒息冲锋！……对手窒息了，我也快窒息了。</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>
@@ -30,13 +31,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="20402" resId="Pets/pet/141.png" name="Lv30 希捷特" size="54,48" pos="265,140" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>虚空炸弹！轰——！</self>
-				<self>穿梭在不同空间之间，有时候会迷路~</self>
-				<self>希捷特的空间跳跃：快、准、偶尔偏。</self>
-			</wanderBubble>
+		<npc id="20402" resId="Pets/pet/141.png" name="Lv30 希捷特" size="54,48" pos="265,140" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>虚空炸弹！轰——！</self>
+					<self>穿梭在不同空间之间，有时候会迷路~</self>
+					<self>希捷特的空间跳跃：快、准、偶尔偏。</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>

--- a/Assets/Resources/Data/Maps/211.xml
+++ b/Assets/Resources/Data/Maps/211.xml
@@ -6,13 +6,14 @@
     	<fx>FX_120</fx>
     </music>
 	<entities>
-		<npc id="21101" resId="Pets/pet/26.png" name="Lv25 安亚" size="36,57" pos="300,120" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>头上的水泡又变大了，是不是快进化了？</self>
-				<self>呼吸罩模式启动！可以在水下待更久啦~</self>
-				<self>墨汁喷射！……把自己也染黑了。</self>
-			</wanderBubble>
+		<npc id="21101" resId="Pets/pet/26.png" name="Lv25 安亚" size="36,57" pos="300,120" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>头上的水泡又变大了，是不是快进化了？</self>
+					<self>呼吸罩模式启动！可以在水下待更久啦~</self>
+					<self>墨汁喷射！……把自己也染黑了。</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>
@@ -47,13 +48,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="21202" resId="Pets/pet/26.png" name="Lv26 安亚" size="36,57" pos="620,80" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>漩涡谷地的水流好急，不过我已经习惯了~</self>
-				<self>气泡咕噜咕噜的，像在唱歌一样~</self>
-				<self>衰退技能练好了！就是有点累。</self>
-			</wanderBubble>
+		<npc id="21202" resId="Pets/pet/26.png" name="Lv26 安亚" size="36,57" pos="620,80" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>漩涡谷地的水流好急，不过我已经习惯了~</self>
+					<self>气泡咕噜咕噜的，像在唱歌一样~</self>
+					<self>衰退技能练好了！就是有点累。</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>

--- a/Assets/Resources/Data/Maps/261.xml
+++ b/Assets/Resources/Data/Maps/261.xml
@@ -6,13 +6,14 @@
 	</music>
 	<initialPoint>390,135</initialPoint>
 	<entities>
-		<npc id="26101" resId="Pets/pet/40.png" name="Lv37 赤焰兽" size="78,73" pos="600,140" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>我的嘴巴能喝岩浆哦！……别问我什么味道。</self>
-				<self>烈焰撞击！感觉自己像一颗流星~</self>
-				<self>赤链山脉的熔浆最好喝了，今天又喝饱了。</self>
-			</wanderBubble>
+		<npc id="26101" resId="Pets/pet/40.png" name="Lv37 赤焰兽" size="78,73" pos="600,140" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>我的嘴巴能喝岩浆哦！……别问我什么味道。</self>
+					<self>烈焰撞击！感觉自己像一颗流星~</self>
+					<self>赤链山脉的熔浆最好喝了，今天又喝饱了。</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true">
@@ -49,13 +50,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="26102" resId="Pets/pet/40.png" name="Lv36 赤焰兽" size="78,73" pos="495,65" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>火球飞弹！嗖——打中了！……打中了谁？</self>
-				<self>有时候会想，如果岩浆喝多了会怎样？</self>
-				<self>赤焰兽出击！小心别被我的热情烫到~</self>
-			</wanderBubble>
+		<npc id="26102" resId="Pets/pet/40.png" name="Lv36 赤焰兽" size="78,73" pos="495,65" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>火球飞弹！嗖——打中了！……打中了谁？</self>
+					<self>有时候会想，如果岩浆喝多了会怎样？</self>
+					<self>赤焰兽出击！小心别被我的热情烫到~</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true">

--- a/Assets/Resources/Data/Maps/291.xml
+++ b/Assets/Resources/Data/Maps/291.xml
@@ -6,13 +6,14 @@
 	</music>
 	<initialPoint>390,135</initialPoint>
 	<entities>
-		<npc id="29101" resId="Pets/pet/33.png" name="Lv31 乔尼" size="58,78" pos="580,140" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>身后的火烧得好旺！不撞点什么就憋得慌~</self>
-				<self>火焰冲撞！冲冲冲！</self>
-				<self>双轨火炮准备！……呃，炮口朝哪来着？</self>
-			</wanderBubble>
+		<npc id="29101" resId="Pets/pet/33.png" name="Lv31 乔尼" size="58,78" pos="580,140" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>身后的火烧得好旺！不撞点什么就憋得慌~</self>
+					<self>火焰冲撞！冲冲冲！</self>
+					<self>双轨火炮准备！……呃，炮口朝哪来着？</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true" />
@@ -47,13 +48,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="29102" resId="Pets/pet/33.png" name="Lv32 乔尼" size="58,78" pos="320,225" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>大家别靠太近，我身后真的很烫！</self>
-				<self>有时候停下来就会过热，只好一直跑~</self>
-				<self>幻空通道的风好大，把我的火焰吹得东倒西歪的。</self>
-			</wanderBubble>
+		<npc id="29102" resId="Pets/pet/33.png" name="Lv32 乔尼" size="58,78" pos="320,225" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>大家别靠太近，我身后真的很烫！</self>
+					<self>有时候停下来就会过热，只好一直跑~</self>
+					<self>幻空通道的风好大，把我的火焰吹得东倒西歪的。</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true" />

--- a/Assets/Resources/Data/Maps/301.xml
+++ b/Assets/Resources/Data/Maps/301.xml
@@ -6,13 +6,14 @@
 	</music>
 	<initialPoint>420,170</initialPoint>
 	<entities>
-		<npc id="30101" resId="Pets/pet/35.png" name="Lv33 大角岩浮" size="58,63" pos="650,170" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>今天又找了半天，还是没找到……但我不灰心！</self>
-				<self>也许那个东西根本不在这里？不，一定在！</self>
-				<self>角上沾满了火山灰，看起来像戴了顶帽子~</self>
-			</wanderBubble>
+		<npc id="30101" resId="Pets/pet/35.png" name="Lv33 大角岩浮" size="58,63" pos="650,170" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>今天又找了半天，还是没找到……但我不灰心！</self>
+					<self>也许那个东西根本不在这里？不，一定在！</self>
+					<self>角上沾满了火山灰，看起来像戴了顶帽子~</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true" />
@@ -47,13 +48,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="30102" resId="Pets/pet/35.png" name="Lv34 大角岩浮" size="58,63" pos="490,230" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>我总觉得忘记了什么很重要的东西……</self>
-				<self>火山口找了好久了，到底丢在哪了呢？</self>
-				<self>大力钳！夹住了一块……普通的石头。</self>
-			</wanderBubble>
+		<npc id="30102" resId="Pets/pet/35.png" name="Lv34 大角岩浮" size="58,63" pos="490,230" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>我总觉得忘记了什么很重要的东西……</self>
+					<self>火山口找了好久了，到底丢在哪了呢？</self>
+					<self>大力钳！夹住了一块……普通的石头。</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true" />
@@ -88,13 +90,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="30103" resId="Pets/pet/35.png" name="Lv35 大角岩浮" size="58,63" pos="320,170" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>热力钳练好了！就是有点烫手~</self>
-				<self>灰烬之地到处都是灰，但我不放弃！</self>
-				<self>火球连射！嗖嗖嗖——全打在岩壁上了。</self>
-			</wanderBubble>
+		<npc id="30103" resId="Pets/pet/35.png" name="Lv35 大角岩浮" size="58,63" pos="320,170" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>热力钳练好了！就是有点烫手~</self>
+					<self>灰烬之地到处都是灰，但我不放弃！</self>
+					<self>火球连射！嗖嗖嗖——全打在岩壁上了。</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true" />

--- a/Assets/Resources/Data/Maps/310.xml
+++ b/Assets/Resources/Data/Maps/310.xml
@@ -5,13 +5,14 @@
 		<bgm>BGM_310</bgm>
 	</music>
 	<entities>
-		<npc id="31001" resId="Pets/pet/114.png" name="Lv51 蹦蹦鼠" size="82,80" pos="675,120" namePos="15,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>以守转攻！先防守再反击，聪明的战术~</self>
-				<self>今天跳了1000下，腿有点酸。</self>
-				<self>蹦蹦鼠的尾巴：平衡大师，兼职方向盘。</self>
-			</wanderBubble>
+		<npc id="31001" resId="Pets/pet/114.png" name="Lv51 蹦蹦鼠" size="82,80" pos="675,120" namePos="15,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>以守转攻！先防守再反击，聪明的战术~</self>
+					<self>今天跳了1000下，腿有点酸。</self>
+					<self>蹦蹦鼠的尾巴：平衡大师，兼职方向盘。</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>
@@ -29,13 +30,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="31002" resId="Pets/pet/114.png" name="Lv52 蹦蹦鼠" size="82,80" pos="465,95" namePos="15,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>蹦！蹦！蹦！停不下来啦~</self>
-				<self>尾巴是我的秘密武器，平衡感全靠它！</self>
-				<self>沙之刀刃！沙子也能变成武器~</self>
-			</wanderBubble>
+		<npc id="31002" resId="Pets/pet/114.png" name="Lv52 蹦蹦鼠" size="82,80" pos="465,95" namePos="15,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>蹦！蹦！蹦！停不下来啦~</self>
+					<self>尾巴是我的秘密武器，平衡感全靠它！</self>
+					<self>沙之刀刃！沙子也能变成武器~</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>

--- a/Assets/Resources/Data/Maps/360.xml
+++ b/Assets/Resources/Data/Maps/360.xml
@@ -71,13 +71,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="36001" resId="Pets/pet/69.png" name="Lv53 蛋壳鸡" size="58,90" pos="390,55" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>飞沙走石！……主要是沙子。</self>
-				<self>黄金之路果然是金色的……不对，是沙色的。</self>
-				<self>蛋壳是我的家，也是我的武器！</self>
-			</wanderBubble>
+		<npc id="36001" resId="Pets/pet/69.png" name="Lv53 蛋壳鸡" size="58,90" pos="390,55" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>飞沙走石！……主要是沙子。</self>
+					<self>黄金之路果然是金色的……不对，是沙色的。</self>
+					<self>蛋壳是我的家，也是我的武器！</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>
@@ -103,13 +104,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="36002" resId="Pets/pet/69.png" name="Lv54 蛋壳鸡" size="58,90" pos="155,135" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>沙之脚！在沙地上跑得飞快~</self>
-				<self>走遍千山万水，还是觉得自己的蛋壳最舒服。</self>
-				<self>今天又领悟了一个秘密……然后忘了。</self>
-			</wanderBubble>
+		<npc id="36002" resId="Pets/pet/69.png" name="Lv54 蛋壳鸡" size="58,90" pos="155,135" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>沙之脚！在沙地上跑得飞快~</self>
+					<self>走遍千山万水，还是觉得自己的蛋壳最舒服。</self>
+					<self>今天又领悟了一个秘密……然后忘了。</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>

--- a/Assets/Resources/Data/Maps/401.xml
+++ b/Assets/Resources/Data/Maps/401.xml
@@ -6,13 +6,14 @@
 	</music>
 	<entities>
 
-		<npc id="40101" resId="Pets/pet/122.png" name="Lv61 冻气龟" size="45,58" pos="350,230" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>我不是驼子！这是冰壳！冰壳！</self>
-				<self>冻气附体！暴击率提升~</self>
-				<self>冰之谷好冷，但对我来说刚刚好~</self>
-			</wanderBubble>
+		<npc id="40101" resId="Pets/pet/122.png" name="Lv61 冻气龟" size="45,58" pos="350,230" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>我不是驼子！这是冰壳！冰壳！</self>
+					<self>冻气附体！暴击率提升~</self>
+					<self>冰之谷好冷，但对我来说刚刚好~</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>
@@ -30,13 +31,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="40102" resId="Pets/pet/122.png" name="Lv60 冻气龟" size="45,58" pos="520,120" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>小时候被嘲笑的事……哼，现在谁还敢笑我？</self>
-				<self>重击！龟壳一顶，对手飞出去~</self>
-				<self>冻气龟出击！小心别被冻到~</self>
-			</wanderBubble>
+		<npc id="40102" resId="Pets/pet/122.png" name="Lv60 冻气龟" size="45,58" pos="520,120" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>小时候被嘲笑的事……哼，现在谁还敢笑我？</self>
+					<self>重击！龟壳一顶，对手飞出去~</self>
+					<self>冻气龟出击！小心别被冻到~</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>

--- a/Assets/Resources/Data/Maps/402.xml
+++ b/Assets/Resources/Data/Maps/402.xml
@@ -5,13 +5,14 @@
 		<bgm>BGM_045</bgm>
 	</music>
 	<entities>
-		<npc id="40201" resId="Pets/pet/128.png" name="Lv65 波利" size="46,55" pos="350,150" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>对手体力低于一半时，我的伤害增加15%！</self>
-				<self>掷冰！冰块飞飞飞~</self>
-				<self>万人迷的烦恼：大家都看着我，好害羞~</self>
-			</wanderBubble>
+		<npc id="40201" resId="Pets/pet/128.png" name="Lv65 波利" size="46,55" pos="350,150" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>对手体力低于一半时，我的伤害增加15%！</self>
+					<self>掷冰！冰块飞飞飞~</self>
+					<self>万人迷的烦恼：大家都看着我，好害羞~</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>
@@ -29,13 +30,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="40202" resId="Pets/pet/128.png" name="Lv64 波利" size="46,55" pos="600,200" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>我可是冰脊山脉的人气王！迷倒万千精灵~</self>
-				<self>怪笑！后出手必中，跑不掉的！</self>
-				<self>寒冰咆哮！嗷呜——！</self>
-			</wanderBubble>
+		<npc id="40202" resId="Pets/pet/128.png" name="Lv64 波利" size="46,55" pos="600,200" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>我可是冰脊山脉的人气王！迷倒万千精灵~</self>
+					<self>怪笑！后出手必中，跑不掉的！</self>
+					<self>寒冰咆哮！嗷呜——！</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>

--- a/Assets/Resources/Data/Maps/405.xml
+++ b/Assets/Resources/Data/Maps/405.xml
@@ -5,13 +5,14 @@
 		<bgm>BGM_028</bgm>
 	</music>
 	<entities>
-		<npc id="40501" resId="Pets/pet/124.png" name="Lv67 伊露" size="47,49" pos="350,150" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>今天幻想自己是一只大鸟，飞过了冰原~</self>
-				<self>幻想特性！有幻想时受伤减少15%！</self>
-				<self>冰沁宫殿好安静，适合想东想西~</self>
-			</wanderBubble>
+		<npc id="40501" resId="Pets/pet/124.png" name="Lv67 伊露" size="47,49" pos="350,150" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>今天幻想自己是一只大鸟，飞过了冰原~</self>
+					<self>幻想特性！有幻想时受伤减少15%！</self>
+					<self>冰沁宫殿好安静，适合想东想西~</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>
@@ -29,13 +30,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="40502" resId="Pets/pet/124.png" name="Lv66 伊露" size="47,49" pos="600,200" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>坚定！不管发生什么，我都很坚定！</self>
-				<self>踩踏！小心脚下~</self>
-				<self>有时候幻想和现实分不清……不过这样也挺好玩的~</self>
-			</wanderBubble>
+		<npc id="40502" resId="Pets/pet/124.png" name="Lv66 伊露" size="47,49" pos="600,200" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>坚定！不管发生什么，我都很坚定！</self>
+					<self>踩踏！小心脚下~</self>
+					<self>有时候幻想和现实分不清……不过这样也挺好玩的~</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>

--- a/Assets/Resources/Data/Maps/407.xml
+++ b/Assets/Resources/Data/Maps/407.xml
@@ -5,13 +5,14 @@
 		<bgm>BGM_JY</bgm>
 	</music>
 	<entities>
-		<npc id="40701" resId="Pets/pet/228.png" name="Lv63 米诺" size="32,48" pos="300,120" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>米诺不唱歌！米诺只打架！</self>
-				<self>重击！简单粗暴~</self>
-				<self>冰沁氏族的歌声……其实也没有那么难听啦。</self>
-			</wanderBubble>
+		<npc id="40701" resId="Pets/pet/228.png" name="Lv63 米诺" size="32,48" pos="300,120" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>米诺不唱歌！米诺只打架！</self>
+					<self>重击！简单粗暴~</self>
+					<self>冰沁氏族的歌声……其实也没有那么难听啦。</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>
@@ -29,13 +30,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="40702" resId="Pets/pet/228.png" name="Lv62 米诺" size="32,48" pos="500,120" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>暗施冷箭！偷偷地~</self>
-				<self>盗取！拿了对手的东西~</self>
-				<self>陷阱！踩到了吧？恢复15点怒气~</self>
-			</wanderBubble>
+		<npc id="40702" resId="Pets/pet/228.png" name="Lv62 米诺" size="32,48" pos="500,120" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>暗施冷箭！偷偷地~</self>
+					<self>盗取！拿了对手的东西~</self>
+					<self>陷阱！踩到了吧？恢复15点怒气~</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>

--- a/Assets/Resources/Data/Maps/408.xml
+++ b/Assets/Resources/Data/Maps/408.xml
@@ -6,13 +6,14 @@
 	</music>
 	<entities>
 		
-		<npc id="40801" resId="Pets/pet/138.png" name="Lv70 多利" size="38,45" pos="400,220" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>我身上的襁褓有咒文哦！具体是什么……我也不清楚。</self>
-				<self>雪球！来打雪仗吧~</self>
-				<self>原始雪森林的雪好白好软~</self>
-			</wanderBubble>
+		<npc id="40801" resId="Pets/pet/138.png" name="Lv70 多利" size="38,45" pos="400,220" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>我身上的襁褓有咒文哦！具体是什么……我也不清楚。</self>
+					<self>雪球！来打雪仗吧~</self>
+					<self>原始雪森林的雪好白好软~</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>
@@ -31,13 +32,14 @@
 			</eventHandler>
 		</npc>
 		<!--
-		<npc id="40802" resId="Pets/pet/138.png" name="Lv70 多利" size="38,45" pos="600,120" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>我身上的襁褓有咒文哦！具体是什么……我也不清楚。</self>
-				<self>雪球！来打雪仗吧~</self>
-				<self>原始雪森林的雪好白好软~</self>
-			</wanderBubble>
+		<npc id="40802" resId="Pets/pet/138.png" name="Lv70 多利" size="38,45" pos="600,120" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>我身上的襁褓有咒文哦！具体是什么……我也不清楚。</self>
+					<self>雪球！来打雪仗吧~</self>
+					<self>原始雪森林的雪好白好软~</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>

--- a/Assets/Resources/Data/Maps/409.xml
+++ b/Assets/Resources/Data/Maps/409.xml
@@ -7,13 +7,14 @@
 	<entities>
 
 
-		<npc id="40901" resId="Pets/pet/119.png" name="Lv68 豚豚" size="50,57" pos="350,150" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>雪之湖泊好冷，但我的毛很厚！</self>
-				<self>寒冰坚韧！受到伤害减少20点~</self>
-				<self>小时候差点被海浪冲走，现在可不会了！</self>
-			</wanderBubble>
+		<npc id="40901" resId="Pets/pet/119.png" name="Lv68 豚豚" size="50,57" pos="350,150" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>雪之湖泊好冷，但我的毛很厚！</self>
+					<self>寒冰坚韧！受到伤害减少20点~</self>
+					<self>小时候差点被海浪冲走，现在可不会了！</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>
@@ -31,13 +32,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="40902" resId="Pets/pet/119.png" name="Lv69 豚豚" size="50,57" pos="600,200" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>冰川湖泊虽然险恶，但风景真的很美。</self>
-				<self>坚硬！我可是很硬的！</self>
-				<self>豚豚抓紧浮冰中……浪来了！啊——！</self>
-			</wanderBubble>
+		<npc id="40902" resId="Pets/pet/119.png" name="Lv69 豚豚" size="50,57" pos="600,200" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>冰川湖泊虽然险恶，但风景真的很美。</self>
+					<self>坚硬！我可是很硬的！</self>
+					<self>豚豚抓紧浮冰中……浪来了！啊——！</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>

--- a/Assets/Resources/Data/Maps/421.xml
+++ b/Assets/Resources/Data/Maps/421.xml
@@ -5,13 +5,14 @@
 		<bgm>BGM_037</bgm>
 	</music>
 	<entities>
-		<npc id="42101" resId="Pets/pet/213.png" name="Lv78 石像魔" size="109,102" pos="340,45" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>坚硬！我可是很硬的！</self>
-				<self>当所有符文拼在一起，一段历史就会被揭开……</self>
-				<self>石像魔：看起来很凶，其实只是脸比较方。</self>
-			</wanderBubble>
+		<npc id="42101" resId="Pets/pet/213.png" name="Lv78 石像魔" size="109,102" pos="340,45" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>坚硬！我可是很硬的！</self>
+					<self>当所有符文拼在一起，一段历史就会被揭开……</self>
+					<self>石像魔：看起来很凶，其实只是脸比较方。</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>
@@ -29,13 +30,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="42102" resId="Pets/pet/213.png" name="Lv79 石像魔" size="109,102" pos="130,160" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>我身上的符文你认识吗？反正我自己不认识。</self>
-				<self>石化冲击！变成石头……不是，是让对手变石头！</self>
-				<self>飞翼之核的风好大，差点把我吹跑了。</self>
-			</wanderBubble>
+		<npc id="42102" resId="Pets/pet/213.png" name="Lv79 石像魔" size="109,102" pos="130,160" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>我身上的符文你认识吗？反正我自己不认识。</self>
+					<self>石化冲击！变成石头……不是，是让对手变石头！</self>
+					<self>飞翼之核的风好大，差点把我吹跑了。</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>

--- a/Assets/Resources/Data/Maps/422.xml
+++ b/Assets/Resources/Data/Maps/422.xml
@@ -5,13 +5,14 @@
 		<bgm>BGM_031</bgm>
 	</music>
 	<entities>
-		<npc id="42201" resId="Pets/pet/195.png" name="Lv73 克里普特" size="75,77" pos="410,45" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>勘探报告：前方安全……大概。</self>
-				<self>弑龙弹！虽然没见过龙，但万一呢？</self>
-				<self>时镜之岛好多镜子，照来照去的。</self>
-			</wanderBubble>
+		<npc id="42201" resId="Pets/pet/195.png" name="Lv73 克里普特" size="75,77" pos="410,45" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>勘探报告：前方安全……大概。</self>
+					<self>弑龙弹！虽然没见过龙，但万一呢？</self>
+					<self>时镜之岛好多镜子，照来照去的。</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>
@@ -29,13 +30,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="42202" resId="Pets/pet/195.png" name="Lv72 克里普特" size="75,77" pos="600,45" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>燃烧弹！虽然是超能系的，但谁规定不能放火？</self>
-				<self>克里普特在此！有危险找我！</self>
-				<self>勘探精灵的日常：去危险的地方，写安全的报告。</self>
-			</wanderBubble>
+		<npc id="42202" resId="Pets/pet/195.png" name="Lv72 克里普特" size="75,77" pos="600,45" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>燃烧弹！虽然是超能系的，但谁规定不能放火？</self>
+					<self>克里普特在此！有危险找我！</self>
+					<self>勘探精灵的日常：去危险的地方，写安全的报告。</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>

--- a/Assets/Resources/Data/Maps/424.xml
+++ b/Assets/Resources/Data/Maps/424.xml
@@ -5,13 +5,14 @@
 		<bgm>BGM_033</bgm>
 	</music>
 	<entities>
-		<npc id="42401" resId="Pets/pet/209.png" name="Lv76 安吉丽塔" size="80,97" pos="320,65" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>虽然会飞，但我更喜欢在水里~</self>
-				<self>流体贯穿！水流穿过去~</self>
-				<self>汲雨之岛的雨水好温柔。</self>
-			</wanderBubble>
+		<npc id="42401" resId="Pets/pet/209.png" name="Lv76 安吉丽塔" size="80,97" pos="320,65" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>虽然会飞，但我更喜欢在水里~</self>
+					<self>流体贯穿！水流穿过去~</self>
+					<self>汲雨之岛的雨水好温柔。</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>
@@ -29,13 +30,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="42402" resId="Pets/pet/209.png" name="Lv77 安吉丽塔" size="80,97" pos="840,190" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>流水激射！水花四溅~</self>
-				<self>激流冲撞！像一条小瀑布~</self>
-				<self>大家问我为什么不去天上飞……水里更舒服嘛！</self>
-			</wanderBubble>
+		<npc id="42402" resId="Pets/pet/209.png" name="Lv77 安吉丽塔" size="80,97" pos="840,190" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>流水激射！水花四溅~</self>
+					<self>激流冲撞！像一条小瀑布~</self>
+					<self>大家问我为什么不去天上飞……水里更舒服嘛！</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>

--- a/Assets/Resources/Data/Maps/425.xml
+++ b/Assets/Resources/Data/Maps/425.xml
@@ -5,13 +5,14 @@
 		<bgm>BGM_035</bgm>
 	</music>
 	<entities>
-		<npc id="42501" resId="Pets/pet/199.png" name="Lv74 泰姆尔" size="67,77" pos="340,45" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>时光倒流！如果能回到过去就好了……</self>
-				<self>时光冲击！把时间的力量打出去~</self>
-				<self>羽冠之岛的大家都靠我报时，压力好大！</self>
-			</wanderBubble>
+		<npc id="42501" resId="Pets/pet/199.png" name="Lv74 泰姆尔" size="67,77" pos="340,45" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>时光倒流！如果能回到过去就好了……</self>
+					<self>时光冲击！把时间的力量打出去~</self>
+					<self>羽冠之岛的大家都靠我报时，压力好大！</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>
@@ -29,13 +30,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="42502" resId="Pets/pet/199.png" name="Lv71 泰姆尔" size="67,77" pos="620,45" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>时光倒流！如果能回到过去就好了……</self>
-				<self>时光冲击！把时间的力量打出去~</self>
-				<self>羽冠之岛的大家都靠我报时，压力好大！</self>
-			</wanderBubble>
+		<npc id="42502" resId="Pets/pet/199.png" name="Lv71 泰姆尔" size="67,77" pos="620,45" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>时光倒流！如果能回到过去就好了……</self>
+					<self>时光冲击！把时间的力量打出去~</self>
+					<self>羽冠之岛的大家都靠我报时，压力好大！</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>

--- a/Assets/Resources/Data/Maps/480.xml
+++ b/Assets/Resources/Data/Maps/480.xml
@@ -5,13 +5,14 @@
 		<bgm>BGM_470</bgm>
 	</music>
 	<entities>
-		<npc id="36001" resId="Pets/pet/54.png" name="Lv48 牛顿" size="107,77" pos="670,140" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>坚韧！我可是很坚韧的牛！</self>
-				<self>地心引力真神奇，它让一切都有了方向。</self>
-				<self>牛顿在这里思考人生……其实是发呆啦~</self>
-			</wanderBubble>
+		<npc id="36001" resId="Pets/pet/54.png" name="Lv48 牛顿" size="107,77" pos="670,140" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>坚韧！我可是很坚韧的牛！</self>
+					<self>地心引力真神奇，它让一切都有了方向。</self>
+					<self>牛顿在这里思考人生……其实是发呆啦~</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>
@@ -29,13 +30,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="36002" resId="Pets/pet/54.png" name="Lv49 牛顿" size="107,77" pos="400,50" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>我终于明白了！是地心引力！是地心引力让苹果掉下来的！</self>
-				<self>群牛践踏！……只有我一个牛，但气势不能输！</self>
-				<self>地铁站里好暗，不过我自带电光~</self>
-			</wanderBubble>
+		<npc id="36002" resId="Pets/pet/54.png" name="Lv49 牛顿" size="107,77" pos="400,50" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>我终于明白了！是地心引力！是地心引力让苹果掉下来的！</self>
+					<self>群牛践踏！……只有我一个牛，但气势不能输！</self>
+					<self>地铁站里好暗，不过我自带电光~</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>

--- a/Assets/Resources/Data/Maps/490.xml
+++ b/Assets/Resources/Data/Maps/490.xml
@@ -5,13 +5,14 @@
 		<bgm>BGM_470</bgm>
 	</music>
 	<entities>
-		<npc id="49002" resId="Pets/pet/203.png" name="Lv46 碎晶蜂" size="82,71" pos="445,65" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>我的身体在发光……是因为吃了太多矿石。</self>
-				<self>振翅突击！嗡嗡嗡~</self>
-				<self>地下黑市的矿石真好吃……啊不是，真好看。</self>
-			</wanderBubble>
+		<npc id="49002" resId="Pets/pet/203.png" name="Lv46 碎晶蜂" size="82,71" pos="445,65" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>我的身体在发光……是因为吃了太多矿石。</self>
+					<self>振翅突击！嗡嗡嗡~</self>
+					<self>地下黑市的矿石真好吃……啊不是，真好看。</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>
@@ -29,13 +30,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="49003" resId="Pets/pet/203.png" name="Lv47 碎晶蜂" size="82,71" pos="700,135" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>蜂皇迷针！针针针~</self>
-				<self>加速！速度越来越快！</self>
-				<self>变成结晶体之后，感觉身体硬邦邦的。</self>
-			</wanderBubble>
+		<npc id="49003" resId="Pets/pet/203.png" name="Lv47 碎晶蜂" size="82,71" pos="700,135" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>蜂皇迷针！针针针~</self>
+					<self>加速！速度越来越快！</self>
+					<self>变成结晶体之后，感觉身体硬邦邦的。</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>

--- a/Assets/Resources/Data/Maps/510.xml
+++ b/Assets/Resources/Data/Maps/510.xml
@@ -5,13 +5,14 @@
 		<bgm>BGM_520</bgm>
 	</music>
 	<entities>
-		<npc id="51002" resId="Pets/pet/64.png" name="Lv43 格尔西克" size="61,45" pos="330,190" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>我没有生气！我天生就长这样！</self>
-				<self>胆子变大了！今天敢跟一只蝴蝶对视了！</self>
-				<self>尘土飞扬！……咳咳，呛到了。</self>
-			</wanderBubble>
+		<npc id="51002" resId="Pets/pet/64.png" name="Lv43 格尔西克" size="61,45" pos="330,190" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>我没有生气！我天生就长这样！</self>
+					<self>胆子变大了！今天敢跟一只蝴蝶对视了！</self>
+					<self>尘土飞扬！……咳咳，呛到了。</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>
@@ -37,13 +38,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="51003" resId="Pets/pet/64.png" name="Lv44 格尔西克" size="61,45" pos="210,130" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>锐减！把对手的能力减下去~</self>
-				<self>蛮力冲锋！冲啊——！</self>
-				<self>地道之路好黑，但我不怕！……好吧有一点点怕。</self>
-			</wanderBubble>
+		<npc id="51003" resId="Pets/pet/64.png" name="Lv44 格尔西克" size="61,45" pos="210,130" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>锐减！把对手的能力减下去~</self>
+					<self>蛮力冲锋！冲啊——！</self>
+					<self>地道之路好黑，但我不怕！……好吧有一点点怕。</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>

--- a/Assets/Resources/Data/Maps/520.xml
+++ b/Assets/Resources/Data/Maps/520.xml
@@ -30,13 +30,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="52002" resId="Pets/pet/88.png" name="Lv41 皮格" size="53,38" pos="740,140" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>念动力！看我的！……只移动了一颗石子。</self>
-				<self>振奋！精神满满！</self>
-				<self>皮格的催眠术可是百发百中哦~大概。</self>
-			</wanderBubble>
+		<npc id="52002" resId="Pets/pet/88.png" name="Lv41 皮格" size="53,38" pos="740,140" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>念动力！看我的！……只移动了一颗石子。</self>
+					<self>振奋！精神满满！</self>
+					<self>皮格的催眠术可是百发百中哦~大概。</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>
@@ -54,13 +55,14 @@
 				</button>
 			</eventHandler>
 		</npc>
-		<npc id="52003" resId="Pets/pet/88.png" name="Lv42 皮格" size="53,38" pos="400,85" namePos="0,0" wander="true" wanderRadius="220" wanderSpeed="34" wanderIdle="2,3" wanderStep="12,26" wanderMoveTick="0.05" wanderSnap="1" wanderBob="1.25" wanderBobSpeed="2" wanderOriginalFacesRight="true" wanderBubbleChance="0.3" wanderBubbleDuration="2.5">
-			
-			<wanderBubble>
-				<self>光系精灵在黑暗中也能发光，是不是很酷？</self>
-				<self>催眠暗示发动！3、2、1……睡着了吗？</self>
-				<self>矿坑里其他精灵都躲着我，不知道为什么~</self>
-			</wanderBubble>
+		<npc id="52003" resId="Pets/pet/88.png" name="Lv42 皮格" size="53,38" pos="400,85" namePos="0,0">
+			<wander enabled="true" radius="220" speed="34" idle="2,3" step="12,26" moveTick="0.05" snap="1" bob="1.25" bobSpeed="2" originalFacesRight="true">
+				<bubble chance="0.3" duration="2.5">
+					<self>光系精灵在黑暗中也能发光，是不是很酷？</self>
+					<self>催眠暗示发动！3、2、1……睡着了吗？</self>
+					<self>矿坑里其他精灵都躲着我，不知道为什么~</self>
+				</bubble>
+			</wander>
 			<battle>
 				<branch id="default">
 					<settings count="6" capture="true"/>


### PR DESCRIPTION
参数名从 wanderXxx 改为 <wander xxx> 节点属性，涉及 40 个地图文件，包括 87 个 NPC 全部迁移到新格式。暂时排除了121.xml / 420.xml / 423.xml / 1088.xml。