### PR TITLE
Update BattleDamageAnimView.cs

### DIFF
--- a/Assets/Scripts/MVC/View/Battle/Components/Anim/BattleDamageAnimView.cs
+++ b/Assets/Scripts/MVC/View/Battle/Components/Anim/BattleDamageAnimView.cs
@@ -141,7 +141,7 @@ public class BattleDamageAnimView : Module
         script.Rect.anchoredPosition = damageAnchoredPos;
         holder.transform.SetAsLastSibling();
 
-        if (isDamage || (!isFinalDamage && isHit))
+        if (isHit && damage != 0)
         {
             script.InstantiateDamageNum(damage, isCritical);
         }


### PR DESCRIPTION
修复了连击段伤害中，伤害在语义上满足“吸收”但依然错误创建“0伤害”贴图导致和“吸收”贴图重叠的问题
<img width="1001" height="566" alt="19433adf-e38e-45b7-9b0f-9b144069c0bc" src="https://github.com/user-attachments/assets/71d42282-3a0b-4b0d-bbea-8a39a9068266" />
